### PR TITLE
check_fit_check_is_fitted fails for 1D estimators 

### DIFF
--- a/skdownscale/pointwise_models/bcsd.py
+++ b/skdownscale/pointwise_models/bcsd.py
@@ -204,6 +204,7 @@ class BcsdPrecipitation(BcsdBase):
                 'check_dont_overwrite_parameters': 'BCSD only suppers 1 feature',
                 'check_fit_idempotent': 'BCSD only suppers 1 feature',
                 'check_n_features_in': 'BCSD only suppers 1 feature',
+                'check_fit_check_is_fitted': 'BCSD only suppers 1 feature',
                 'check_methods_sample_order_invariance': 'temporal order matters',
             },
         }
@@ -317,6 +318,7 @@ class BcsdTemperature(BcsdBase):
                 'check_dont_overwrite_parameters': 'BCSD only suppers 1 feature',
                 'check_fit_idempotent': 'BCSD only suppers 1 feature',
                 'check_n_features_in': 'BCSD only suppers 1 feature',
+                'check_fit_check_is_fitted': 'BCSD only suppers 1 feature',
                 'check_methods_sample_order_invariance': 'temporal order matters',
             },
         }

--- a/skdownscale/pointwise_models/quantile.py
+++ b/skdownscale/pointwise_models/quantile.py
@@ -392,6 +392,7 @@ class QuantileMappingReressor(RegressorMixin, BaseEstimator):
                 'check_supervised_y_2d': 'QuantileMappingReressor only suppers 1 feature',
                 'check_regressors_int': 'QuantileMappingReressor only suppers 1 feature',
                 'check_methods_sample_order_invariance': 'QuantileMappingReressor only suppers 1 feature',
+                'check_fit_check_is_fitted': 'QuantileMappingReressor only suppers 1 feature',
             },
         }
 

--- a/skdownscale/pointwise_models/zscore.py
+++ b/skdownscale/pointwise_models/zscore.py
@@ -124,6 +124,7 @@ class ZScoreRegressor(TimeSynchronousDownscaler):
                 'check_dont_overwrite_parameters': 'Zscore only suppers 1 feature',
                 'check_fit_idempotent': 'Zscore only suppers 1 feature',
                 'check_n_features_in': 'Zscore only suppers 1 feature',
+                'check_fit_check_is_fitted': 'Zscore only suppers 1 feature',
                 'check_methods_sample_order_invariance': 'temporal order matters',
             },
         }


### PR DESCRIPTION
sklearn `check_fit_check_is_fitted` [uses 2 features by default](https://github.com/scikit-learn/scikit-learn/blob/c498314/sklearn/utils/estimator_checks.py#L3550-L3557), thus the test fails for estimators that require only 1 input features. Marking these as xfails 