### PR TITLE
Return 3 columns from GARD models 

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,12 +7,6 @@ on:
     branches: main
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-python@v2.3.1
-      - uses: pre-commit/action@v2.0.3
   test:
     name: ${{ matrix.python-version }}-build
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  autoupdate_schedule: quarterly
+  autofix_prs: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy as np
+import pandas as pd
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.metrics import mean_squared_error
@@ -20,7 +21,7 @@ def select_analogs(analogs, inds):
 
 
 class AnalogBase(RegressorMixin, BaseEstimator):
-    _fit_attributes = ['kdtree_', 'X_', 'y_', 'k_', 'prediction_error_', 'exceedance_prob_']
+    _fit_attributes = ['kdtree_', 'X_', 'y_', 'k_']
 
     def fit(self, X, y):
         """ Fit Analog model using a KDTree
@@ -37,8 +38,6 @@ class AnalogBase(RegressorMixin, BaseEstimator):
         self : returns an instance of self.
         """
         X, y = self._validate_data(X, y=y, y_numeric=True)
-        self.prediction_error_ = []  # populated in predict methods
-        self.exceedance_prob_ = []  # populated in predict methods
 
         if len(X) >= self.n_analogs:
             self.k_ = self.n_analogs
@@ -57,7 +56,14 @@ class AnalogBase(RegressorMixin, BaseEstimator):
     def _more_tags(self):
         return {
             '_xfail_checks': {
-                'check_dict_unchanged': 'GARD models store prediction error and exceedance probabilities during predict',
+                # following error is due to the difference in y and y_pred shape 
+                'check_fit_score_takes_y': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_pipeline_consistency': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_regressors_train': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                # following error is due to a pandas output instead of numpy 
+                'check_supervised_y_2d': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_methods_sample_order_invariance': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_fit_idempotent': 'GARD models output 3 columns pandas dataframe instead of one during predict',
             },
         }
 
@@ -88,9 +94,12 @@ class AnalogRegression(AnalogBase):
 
     Notes
     -----
-    GARD models store prediction error  (`model.prediction_error_`) and
-    exceedance probabilities (`model.exceedance_prob_`) for the last prediction.
+    GARD models generates three columns in the predict function, the columns include `pred`, the mean prediction value; 
+    `exceedance_prob`, the probability of exceeding self.thresh value; and `prediction_error`, the RMSE associated 
+    with the mean prediction. 
     """
+    # the number of columns outputed in the predict method 
+    n_outputs = 3 
 
     def __init__(
         self,
@@ -101,7 +110,6 @@ class AnalogRegression(AnalogBase):
         logistic_kwargs=None,
         lr_kwargs=None,
     ):
-
         self.n_analogs = n_analogs
         self.thresh = thresh
         self.kdtree_kwargs = kdtree_kwargs
@@ -119,14 +127,12 @@ class AnalogRegression(AnalogBase):
 
         Returns
         -------
-        C : pd.DataFrame, shape (n_samples, 1)
-            Returns predicted values.
+        C : pd.DataFrame, shape (n_samples, self.n_outputs)
+            Returns predicted values, including the mean prediction, exceedance probability, and prediction error
         """
         # validate input data
         check_is_fitted(self)
         X = check_array(X)
-
-        out = np.empty(len(X))
 
         # not used if self.thresh = None, instantiating to keep the code clean
         logistic_kwargs = default_none_kwargs(self.logistic_kwargs)
@@ -135,17 +141,14 @@ class AnalogRegression(AnalogBase):
         lr_kwargs = default_none_kwargs(self.lr_kwargs)
         lr_model = LinearRegression(**lr_kwargs)
 
-        # TODO - extract from lr_model's below.
-        self.prediction_error_ = np.zeros(len(X), dtype=np.float64)
-        self.exceedance_prob_ = np.ones(len(X), dtype=np.float64)
-
+        out = np.empty((len(X), self.n_outputs), dtype=np.float64)
         for i in range(len(X)):
             # predict for this time step
-            out[i] = self._predict_one_step(logistic_model, lr_model, X[None, i], i,)
-
+            out[i] = self._predict_one_step(logistic_model, lr_model, X[None, i],)
+        out = pd.DataFrame(out, columns=['pred', 'exceedance_prob', 'prediction_error'])
         return out
 
-    def _predict_one_step(self, logistic_model, lr_model, X, i):
+    def _predict_one_step(self, logistic_model, lr_model, X):
         # get analogs
         query_kwargs = default_none_kwargs(self.query_kwargs)
         inds = self.kdtree_.query(X, k=self.k_, return_distance=False, **query_kwargs).squeeze()
@@ -164,9 +167,9 @@ class AnalogRegression(AnalogBase):
         binary_y = exceed_ind.astype(np.int8)
         if not np.all(binary_y == 1):
             logistic_model.fit(x, binary_y)
-            self.exceedance_prob_[i] = logistic_model.predict_proba(X)[0, 0]
+            exceedance_prob = logistic_model.predict_proba(X)[0, 0]
         else:
-            self.exceedance_prob_[i] = 1.0
+            exceedance_prob = 1.0
 
         # train linear regression model on data above threshold of interest
         lr_model.fit(x[exceed_ind], y[exceed_ind])
@@ -174,11 +177,10 @@ class AnalogRegression(AnalogBase):
         # calculate the rmse of prediction
         y_hat = lr_model.predict(x[exceed_ind])
         error = mean_squared_error(y[exceed_ind], y_hat, squared=False)
-        self.prediction_error_[i] = error
 
         predicted = lr_model.predict(X)
 
-        return predicted
+        return [predicted, exceedance_prob, error]
 
 
 class PureAnalog(AnalogBase):
@@ -203,9 +205,11 @@ class PureAnalog(AnalogBase):
 
     Notes
     -----
-    GARD models store prediction error  (`model.prediction_error_`) and
-    exceedance probabilities (`model.exceedance_prob_`) for the last prediction.
+    GARD models generates three columns in the predict function, the columns include `pred`, the mean prediction value; 
+    `exceedance_prob`, the probability of exceeding self.thresh value; and `prediction_error`, the RMSE associated 
+    with the mean prediction. 
     """
+    n_outputs = 3
 
     def __init__(
         self, n_analogs=200, kind='best_analog', thresh=None, kdtree_kwargs=None, query_kwargs=None,
@@ -226,8 +230,8 @@ class PureAnalog(AnalogBase):
 
         Returns
         -------
-        C : pd.DataFrame, shape (n_samples, 1)
-            Returns predicted values.
+        C : pd.DataFrame, shape (n_samples, self.n_outputs)
+            Returns predicted values, including the mean prediction, exceedance probability, and prediction error
         """
         # validate input data
         check_is_fitted(self)
@@ -284,13 +288,20 @@ class PureAnalog(AnalogBase):
             # for mean/weight cases, this fills nans when all analogs
             # were below thresh
             predicted = np.nan_to_num(predicted, nan=0.0)
-            self.prediction_error_ = masked_analogs.std(axis=1)
-            self.exceedance_prob_ = np.where(analog_mask, 1, 0).mean(axis=1)
+            prediction_error = masked_analogs.std(axis=1)
+            exceedance_prob = np.where(analog_mask, 1, 0).mean(axis=1)
         else:
-            self.prediction_error_ = analogs.std(axis=1)
-            self.exceedance_prob_ = np.ones(len(X), dtype=np.float64)
+            prediction_error = analogs.std(axis=1)
+            exceedance_prob = np.ones(len(X), dtype=np.float64)
 
-        return predicted
+        out = pd.DataFrame(
+            {
+                'pred': predicted,
+                'exceedance_prob': exceedance_prob,
+                'prediction_error': prediction_error
+            }
+        )
+        return out
 
 
 class PureRegression(RegressorMixin, BaseEstimator):
@@ -311,17 +322,17 @@ class PureRegression(RegressorMixin, BaseEstimator):
 
     Notes
     -----
-    GARD pure regression models store prediction error  (`model.prediction_error_`) for the last fit and
-    exceedance probabilities (`model.exceedance_prob_`) for the last prediction.
+    GARD models generates three columns in the predict function, the columns include `pred`, the mean prediction value; 
+    `exceedance_prob`, the probability of exceeding self.thresh value; and `prediction_error`, the RMSE associated 
+    with the mean prediction.
     """
 
     _fit_attributes = [
         'logistic_model_',
         'linear_model_',
-        'prediction_error_',
         'fit_error_',
-        'exceedance_prob_',
     ]
+    n_outputs = 3
 
     def __init__(
         self, thresh=None, logistic_kwargs=None, linear_kwargs=None,
@@ -347,28 +358,54 @@ class PureRegression(RegressorMixin, BaseEstimator):
         y_hat = self.linear_model_.predict(X[exceed_ind])
         error = mean_squared_error(y[exceed_ind], y_hat, squared=False)
         self.fit_error_ = error
-        self.prediction_error_ = []  # populated in predict
-        self.exceedance_prob_ = []  # populated in predict
 
         return self
 
     def predict(self, X):
+        """Predict using the PureRegression model
+
+        Parameters
+        ----------
+        X : pd.Series or pd.DataFrame, shape (n_samples, 1)
+            Samples.
+
+        Returns
+        -------
+        C : pd.DataFrame, shape (n_samples, self.n_outputs)
+            Returns predicted values, including the mean prediction, exceedance probability, and prediction error
+        """
         check_is_fitted(self)
 
         if self.thresh is not None:
-            self.exceedance_prob_ = self.logistic_model_.predict_proba(X)[:, 0]
+            exceedance_prob = self.logistic_model_.predict_proba(X)[:, 0]
         else:
-            self.exceedance_prob_ = np.ones(len(np.asarray(X)), dtype=np.float64)
+            exceedance_prob = np.ones(len(np.asarray(X)), dtype=np.float64)
 
-        self.prediction_error_ = np.full(
+        prediction_error = np.full(
             shape=len(np.asarray(X)), dtype=np.float64, fill_value=self.fit_error_
         )
 
-        return self.linear_model_.predict(X)
+        predicted = self.linear_model_.predict(X)
+
+        out = pd.DataFrame(
+            {
+                'pred': predicted,
+                'exceedance_prob': exceedance_prob,
+                'prediction_error': prediction_error
+            }
+        )
+        return out
 
     def _more_tags(self):
         return {
             '_xfail_checks': {
-                'check_dict_unchanged': 'GARD models store prediction error and exceedance probabilities during predict',
+                # following error is due to the difference in y and y_pred shape 
+                'check_fit_score_takes_y': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_pipeline_consistency': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_regressors_train': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                # following error is due to a pandas output instead of numpy 
+                'check_supervised_y_2d': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_methods_sample_order_invariance': 'GARD models output 3 columns pandas dataframe instead of one during predict',
+                'check_fit_idempotent': 'GARD models output 3 columns pandas dataframe instead of one during predict',
             },
         }

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -100,6 +100,7 @@ class AnalogRegression(AnalogBase):
     """
     # the number of columns outputed in the predict method 
     n_outputs = 3 
+    output_names = ['pred', 'exceedance_prob', 'prediction_error']
 
     def __init__(
         self,
@@ -145,7 +146,9 @@ class AnalogRegression(AnalogBase):
         for i in range(len(X)):
             # predict for this time step
             out[i] = self._predict_one_step(logistic_model, lr_model, X[None, i],)
-        out = pd.DataFrame(out, columns=['pred', 'exceedance_prob', 'prediction_error'])
+
+        if isinstance(X, pd.DataFrame):
+            return pd.DataFrame(out, columns=self.output_names)
         return out
 
     def _predict_one_step(self, logistic_model, lr_model, X):
@@ -210,6 +213,7 @@ class PureAnalog(AnalogBase):
     with the mean prediction. 
     """
     n_outputs = 3
+    output_names = ['pred', 'exceedance_prob', 'prediction_error']
 
     def __init__(
         self, n_analogs=200, kind='best_analog', thresh=None, kdtree_kwargs=None, query_kwargs=None,
@@ -294,14 +298,17 @@ class PureAnalog(AnalogBase):
             prediction_error = analogs.std(axis=1)
             exceedance_prob = np.ones(len(X), dtype=np.float64)
 
-        out = pd.DataFrame(
-            {
-                'pred': predicted,
-                'exceedance_prob': exceedance_prob,
-                'prediction_error': prediction_error
-            }
-        )
-        return out
+        if isinstance(X, pd.DataFrame):
+            out = pd.DataFrame(
+                {
+                    'pred': predicted,
+                    'exceedance_prob': exceedance_prob,
+                    'prediction_error': prediction_error
+                }
+            )
+            return out[self.output_names]
+        else:
+            return np.hstack((predicted, exceedance_prob, prediction_error))
 
 
 class PureRegression(RegressorMixin, BaseEstimator):
@@ -333,6 +340,7 @@ class PureRegression(RegressorMixin, BaseEstimator):
         'fit_error_',
     ]
     n_outputs = 3
+    output_names = ['pred', 'exceedance_prob', 'prediction_error']
 
     def __init__(
         self, thresh=None, logistic_kwargs=None, linear_kwargs=None,
@@ -387,14 +395,17 @@ class PureRegression(RegressorMixin, BaseEstimator):
 
         predicted = self.linear_model_.predict(X)
 
-        out = pd.DataFrame(
-            {
-                'pred': predicted,
-                'exceedance_prob': exceedance_prob,
-                'prediction_error': prediction_error
-            }
-        )
-        return out
+        if isinstance(X, pd.DataFrame):
+            out = pd.DataFrame(
+                {
+                    'pred': predicted,
+                    'exceedance_prob': exceedance_prob,
+                    'prediction_error': prediction_error
+                }
+            )
+            return out[self.output_names]
+        else:
+            return np.hstack((predicted, exceedance_prob, prediction_error))
 
     def _more_tags(self):
         return {

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -144,6 +144,8 @@ class AnalogRegression(AnalogBase):
             # predict for this time step
             out[i] = self._predict_one_step(logistic_model, lr_model, X[None, i],)
 
+        # if the input is a dataframe, return dataframe, otherwise return a numpy array
+        # the output_names can be used to determine the order of columns
         if return_df:
             return pd.DataFrame(out, columns=self.output_names)
         return out
@@ -180,6 +182,7 @@ class AnalogRegression(AnalogBase):
 
         predicted = lr_model.predict(X)
 
+        # this order needs to be the same as output_names
         return [predicted, exceedance_prob, error]
 
 
@@ -297,6 +300,8 @@ class PureAnalog(AnalogBase):
             prediction_error = analogs.std(axis=1)
             exceedance_prob = np.ones(len(X), dtype=np.float64)
 
+        # if the input is a dataframe, return dataframe, otherwise return a numpy array
+        # the output_names can be used to determine the order of columns
         if return_df:
             out = pd.DataFrame(
                 {
@@ -310,6 +315,7 @@ class PureAnalog(AnalogBase):
             predicted = predicted.reshape(-1, 1)
             exceedance_prob = exceedance_prob.reshape(-1, 1)
             prediction_error = prediction_error.reshape(-1, 1)
+            # this order has to be the same as output_names
             return np.hstack((predicted, exceedance_prob, prediction_error))
 
 
@@ -398,6 +404,8 @@ class PureRegression(RegressorMixin, BaseEstimator):
 
         predicted = self.linear_model_.predict(X)
 
+        # if the input is a dataframe, return dataframe, otherwise return a numpy array
+        # the output_names can be used to determine the order of columns
         if return_df:
             out = pd.DataFrame(
                 {
@@ -411,6 +419,7 @@ class PureRegression(RegressorMixin, BaseEstimator):
             predicted = predicted.reshape(-1, 1)
             exceedance_prob = exceedance_prob.reshape(-1, 1)
             prediction_error = prediction_error.reshape(-1, 1)
+            # this order has to be the same as output_names
             return np.hstack((predicted, exceedance_prob, prediction_error))
 
     def _more_tags(self):

--- a/skdownscale/test/test_pointwise_models.py
+++ b/skdownscale/test/test_pointwise_models.py
@@ -160,18 +160,20 @@ def test_gard_analog_models(sample_X_y, kind):
     # test non threshold modeling
     model = PureAnalog(kind=kind, n_analogs=3)
     model.fit(X, y)
-    y_hat = model.predict(X)
-    error = model.prediction_error_
-    prob = model.exceedance_prob_
+    out = model.predict(X)
+    y_hat = out['pred']
+    error = out['prediction_error']
+    prob = out['exceedance_prob']
     assert len(prob) == len(error) == len(y_hat) == len(X)
     assert (prob == 1).all()
 
     # test threshold modeling
     model = PureAnalog(kind=kind, n_analogs=3, thresh=0)
     model.fit(X, y)
-    y_hat = model.predict(X)
-    error = model.prediction_error_
-    prob = model.exceedance_prob_
+    out = model.predict(X)
+    y_hat = out['pred']
+    error = out['prediction_error']
+    prob = out['exceedance_prob']
     assert len(prob) == len(error) == len(y_hat) == len(X)
     assert (prob <= 1).all()
     assert (prob >= 0).all()
@@ -183,9 +185,10 @@ def test_gard_analog_regression_models(sample_X_y, thresh):
 
     model = AnalogRegression(thresh=thresh)
     model.fit(X, y)
-    y_hat = model.predict(X)
-    error = model.prediction_error_
-    prob = model.exceedance_prob_
+    out = model.predict(X)
+    y_hat = out['pred']
+    error = out['prediction_error']
+    prob = out['exceedance_prob']
     assert len(prob) == len(error) == len(y_hat) == len(X)
     if model.thresh:
         assert (prob <= 1).all()
@@ -200,9 +203,10 @@ def test_gard_pure_regression_models(sample_X_y, thresh):
 
     model = PureRegression(thresh=thresh)
     model.fit(X, y)
-    y_hat = model.predict(X)
-    error = model.prediction_error_
-    prob = model.exceedance_prob_
+    out = model.predict(X)
+    y_hat = out['pred']
+    error = out['prediction_error']
+    prob = out['exceedance_prob']
     assert len(prob) == len(error) == len(y_hat) == len(X)
     if model.thresh:
         assert (prob <= 1).all()

--- a/skdownscale/test/test_pointwise_runner.py
+++ b/skdownscale/test/test_pointwise_runner.py
@@ -43,6 +43,7 @@ def test_pointwise_model(X, y):
     model = PointWiseDownscaler(model=pipeline)
     model.fit(X, y)
     y_pred = model.predict(X)
+    y_pred.values  # otherwise some of the code will not be tested when input is chunked
     assert isinstance(y_pred, type(y))
     assert y_pred.sizes == y.sizes
     assert y.chunks == y_pred.chunks
@@ -50,9 +51,13 @@ def test_pointwise_model(X, y):
     model = PointWiseDownscaler(model=AnalogRegression(thresh=0))
     model.fit(X, y)
     y_pred = model.predict(X)
-    assert isinstance(attrs, xr.DataArray)
-    assert attrs.sizes == template_output.sizes
-    assert attrs.dtype == dtype
+    y_pred.values  # otherwise some of the code will not be tested when input is chunked
+    assert isinstance(y_pred, type(y))
+    assert y_pred.sizes['variable'] == model._model.n_outputs
+    for dim in y.sizes:
+        assert y_pred.sizes[dim] == y.sizes[dim]
+    for dim in y.chunksizes:
+        assert y_pred.chunksizes[dim] == y.chunksizes[dim]
 
 
 @pytest.mark.parametrize(

--- a/skdownscale/test/test_pointwise_runner.py
+++ b/skdownscale/test/test_pointwise_runner.py
@@ -47,6 +47,13 @@ def test_pointwise_model(X, y):
     assert y_pred.sizes == y.sizes
     assert y.chunks == y_pred.chunks
 
+    model = PointWiseDownscaler(model=AnalogRegression(thresh=0))
+    model.fit(X, y)
+    y_pred = model.predict(X)
+    assert isinstance(attrs, xr.DataArray)
+    assert attrs.sizes == template_output.sizes
+    assert attrs.dtype == dtype
+
 
 @pytest.mark.parametrize(
     'X',
@@ -122,18 +129,6 @@ def test_pointwise_model_attributes(X, y):
     template_output = X.isel(time=0).drop('time')
     template_output = template_output.expand_dims({'var': np.arange(3)})
     attrs = model.get_attr(key, dtype=dtype, template_output=template_output['a'])
-    assert isinstance(attrs, xr.DataArray)
-    assert attrs.sizes == template_output.sizes
-    assert attrs.dtype == dtype
-
-    # testing an attribute with length equal to X, providing a template output for shape
-    model = PointWiseDownscaler(model=AnalogRegression(thresh=0))
-    model.fit(X, y)
-    model.predict(X)
-    key = 'prediction_error_'
-    dtype = 'float64'
-    template_output = X['a']
-    attrs = model.get_attr(key, dtype=dtype, template_output=template_output)
     assert isinstance(attrs, xr.DataArray)
     assert attrs.sizes == template_output.sizes
     assert attrs.dtype == dtype


### PR DESCRIPTION
* Instead of saving `prediction_error_` and `exceedance_prob_` attributes in GARD models after `.predict`, return all three columns in the `.predict` call. 
* Add `n_outputs` and `output_names` attributes  to GARD models to signal the shape of predict output 
* Modify `predict` and `_predict_wrapper` functions of `PointWiseDownscaler` to accommodate this change. 