### PR TITLE
Add feature names to inputs for GARD model fit

### DIFF
--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -23,10 +23,9 @@ def select_analogs(analogs, inds):
 class NamedColumnBaseEstimator(BaseEstimator):
     # TODO: This class might make more sense to move to base.py so it can be used
     # by other downscaling methods
-    def _validate_data(self,
-                       X="no_validation",
-                       y="no_validation",
-                       **check_params,):
+    def _validate_data(
+        self, X='no_validation', y='no_validation', **check_params,
+    ):
         if isinstance(X, pd.DataFrame):
             feature_names = X.columns
         else:

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -371,7 +371,7 @@ class PureRegression(RegressorMixin, BaseEstimator):
         X, y = self._validate_data(X, y=y, y_numeric=True)
         if feature_names is not False:
             X = pd.DataFrame(X, columns=feature_names)
-        
+
         if self.thresh is not None:
             exceed_ind = y > self.thresh
             binary_y = exceed_ind.astype(np.int8)

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -37,9 +37,11 @@ class AnalogBase(RegressorMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        feature_names = X.columns
+        if isinstance(X, pd.Dataframe):
+            feature_names = X.columns
         X, y = self._validate_data(X, y=y, y_numeric=True)
-        X = pd.DataFrame(X, columns=feature_names)
+        if feature_names:
+            X = pd.DataFrame(X, columns=feature_names)
 
         if len(X) >= self.n_analogs:
             self.k_ = self.n_analogs
@@ -360,9 +362,11 @@ class PureRegression(RegressorMixin, BaseEstimator):
         self.linear_kwargs = linear_kwargs
 
     def fit(self, X, y):
-        feature_names = X.columns
+        if isinstance(X, pd.DataFrame):
+            feature_names = X.columns
         X, y = self._validate_data(X, y=y, y_numeric=True)
-        X = pd.DataFrame(X, columns=feature_names)
+        if feature_names:
+            X = pd.DataFrame(X, columns=feature_names)
         
         if self.thresh is not None:
             exceed_ind = y > self.thresh

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -37,7 +37,9 @@ class AnalogBase(RegressorMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
+        feature_names = X.columns
         X, y = self._validate_data(X, y=y, y_numeric=True)
+        X = pd.DataFrame(X, columns=feature_names)
 
         if len(X) >= self.n_analogs:
             self.k_ = self.n_analogs
@@ -358,8 +360,10 @@ class PureRegression(RegressorMixin, BaseEstimator):
         self.linear_kwargs = linear_kwargs
 
     def fit(self, X, y):
+        feature_names = X.columns
         X, y = self._validate_data(X, y=y, y_numeric=True)
-
+        X = pd.DataFrame(X, columns=feature_names)
+        
         if self.thresh is not None:
             exceed_ind = y > self.thresh
             binary_y = exceed_ind.astype(np.int8)

--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -37,10 +37,12 @@ class AnalogBase(RegressorMixin, BaseEstimator):
         -------
         self : returns an instance of self.
         """
-        if isinstance(X, pd.Dataframe):
+        if isinstance(X, pd.DataFrame):
             feature_names = X.columns
+        else:
+            feature_names = False
         X, y = self._validate_data(X, y=y, y_numeric=True)
-        if feature_names:
+        if feature_names is not False:
             X = pd.DataFrame(X, columns=feature_names)
 
         if len(X) >= self.n_analogs:
@@ -364,8 +366,10 @@ class PureRegression(RegressorMixin, BaseEstimator):
     def fit(self, X, y):
         if isinstance(X, pd.DataFrame):
             feature_names = X.columns
+        else:
+            feature_names = False
         X, y = self._validate_data(X, y=y, y_numeric=True)
-        if feature_names:
+        if feature_names is not False:
             X = pd.DataFrame(X, columns=feature_names)
         
         if self.thresh is not None:


### PR DESCRIPTION
GARD uses `_validate_data` on `X` during the fit, but this removes the data from the pandas Dataframe and returns a numpy array. With this fix we'll save the column names and put the data back into a Dataframe before fitting so that the fitted model has feature names. This mitigates the risk of swapping data columns around during the predict step.