### PR TITLE
Chunks specification in PointWiseDownscaler

### DIFF
--- a/skdownscale/pointwise_models/core.py
+++ b/skdownscale/pointwise_models/core.py
@@ -282,7 +282,11 @@ class PointWiseDownscaler:
                     template = xr.DataArray(
                         np.empty(yshape, dtype=X.dtype), coords=ycoords, dims=ydims
                     )
-                template = template.chunk(X.chunksizes)
+                chunksizes = {}
+                for k, v in X.chunksizes.items():
+                    chunksizes[k] = v
+                chunksizes[kws['feature_dim']] = kws['n_outputs']
+                template = template.chunk(chunksizes)
 
             return xr.map_blocks(
                 _predict_wrapper, X, args=[self._models], kwargs=kws, template=template

--- a/skdownscale/pointwise_models/core.py
+++ b/skdownscale/pointwise_models/core.py
@@ -282,9 +282,7 @@ class PointWiseDownscaler:
                     template = xr.DataArray(
                         np.empty(yshape, dtype=X.dtype), coords=ycoords, dims=ydims
                     )
-                chunksizes = {}
-                for k, v in X.chunksizes.items():
-                    chunksizes[k] = v
+                chunksizes = dict(X.chunksizes)
                 chunksizes[kws['feature_dim']] = kws['n_outputs']
                 template = template.chunk(chunksizes)
 


### PR DESCRIPTION
If you feed in a chunked dataset, ensure that the template passed to `map_blocks` has the same chunk specifications.