### PR TITLE
Add CunnaneTransform, use in QuantileMapper class

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - uses: actions/cache@v2.1.7
+      - uses: actions/cache@v3.0.1
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/dev-requirements.txt') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/ambv/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--line-length", "100", "--skip-string-normalization"]

--- a/skdownscale/pointwise_models/__init__.py
+++ b/skdownscale/pointwise_models/__init__.py
@@ -5,6 +5,7 @@ from .gard import AnalogRegression, PureAnalog, PureRegression
 from .groupers import DAY_GROUPER, MONTH_GROUPER, PaddedDOYGrouper
 from .grouping import GroupedRegressor
 from .quantile import (
+    CunnaneTransformer,
     EquidistantCdfMatcher,
     QuantileMapper,
     QuantileMappingReressor,

--- a/skdownscale/pointwise_models/core.py
+++ b/skdownscale/pointwise_models/core.py
@@ -352,7 +352,9 @@ class PointWiseDownscaler:
         print(X)
         print(self._models)
         if X.chunks:
-            return xr.map_blocks(_transform_wrapper, X, args=[self._models, 'inverse_transform'], kwargs=kws)
+            return xr.map_blocks(
+                _transform_wrapper, X, args=[self._models, 'inverse_transform'], kwargs=kws
+            )
         else:
             return _transform_wrapper(X, self._models, 'inverse_transform', **kws)
 

--- a/skdownscale/pointwise_models/core.py
+++ b/skdownscale/pointwise_models/core.py
@@ -121,7 +121,7 @@ def _transform_wrapper(X, models, direction='transform', feature_dim=DEFAULT_FEA
     shape = list(X.shape)
     coords = dict(X.coords)
     xtrans = xr.DataArray(np.empty(shape, dtype=X.dtype), coords=coords, dims=dims)
-    # print(models)
+
     for index, model in xenumerate(models):
         xdf = X[index].pipe(_da_to_df, feature_dim)
         for key in models.coords.keys():
@@ -349,8 +349,7 @@ class PointWiseDownscaler:
         kws.update(kwargs)
 
         X = self._to_feature_x(X, feature_dim=kws['feature_dim'])
-        print(X)
-        print(self._models)
+
         if X.chunks:
             return xr.map_blocks(
                 _transform_wrapper, X, args=[self._models, 'inverse_transform'], kwargs=kws

--- a/skdownscale/pointwise_models/quantile.py
+++ b/skdownscale/pointwise_models/quantile.py
@@ -4,7 +4,6 @@ import copy
 import numpy as np
 from sklearn.base import BaseEstimator, RegressorMixin, TransformerMixin
 from sklearn.linear_model import LinearRegression
-from sklearn.preprocessing import QuantileTransformer, quantile_transform
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 
@@ -80,8 +79,6 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
 
         qt_kws = default_none_kwargs(self.qt_kwargs, copy=True)
 
-        if 'n_quantiles' not in qt_kws:
-            qt_kws['n_quantiles'] = len(X)
         # maybe detrend the input datasets
         if self.detrend:
             lt_kwargs = default_none_kwargs(self.lt_kwargs)
@@ -90,9 +87,7 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
             x_to_cdf = X
 
         # calculate the cdfs for X
-        # TODO: replace this transformer with something that uses robust
-        # empirical cdf plotting positions
-        qt = QuantileTransformer(**qt_kws)
+        qt = CunnaneTransformer(**qt_kws)
 
         self.x_cdf_fit_ = qt.fit(x_to_cdf)
 
@@ -126,10 +121,8 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
 
         # do the final mapping
         qt_kws = default_none_kwargs(self.qt_kwargs, copy=True)
-        if 'n_quantiles' not in qt_kws:
-            qt_kws['n_quantiles'] = len(X)
 
-        x_quantiles = quantile_transform(x_to_cdf, copy=True, **qt_kws)
+        x_quantiles = CunnaneTransformer(**qt_kws).fit(x_to_cdf).transform(x_to_cdf)
         x_qmapped = self.x_cdf_fit_.inverse_transform(x_quantiles)
 
         # add the trend back
@@ -140,6 +133,34 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
 
     def _more_tags(self):
         return {'_xfail_checks': {'check_methods_subset_invariance': 'because'}}
+
+    def _more_tags(self):
+        return {
+            '_xfail_checks': {
+                'check_estimators_dtypes': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit_score_takes_y': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_data_not_an_array': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_fit_returns_self': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_fit_returns_self(readonly_memmap=True)': 'CunnaneTransformer only suppers 1 feature',
+                'check_dtype_object': 'CunnaneTransformer only suppers 1 feature',
+                'check_pipeline_consistency': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_nan_inf': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_overwrite_params': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_pickle': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit2d_predict1d': 'CunnaneTransformer only suppers 1 feature',
+                'check_methods_subset_invariance': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit2d_1sample': 'CunnaneTransformer only suppers 1 feature',
+                'check_dict_unchanged': 'CunnaneTransformer only suppers 1 feature',
+                'check_dont_overwrite_parameters': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit_idempotent': 'CunnaneTransformer only suppers 1 feature',
+                'check_n_features_in': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_empty_data_messages': 'skip due to odd sklearn string matching in unit test',
+                'check_fit_check_is_fitted': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_general': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_preserve_dtypes': 'CunnaneTransformer only suppers 1 feature',
+                'check_methods_sample_order_invariance': 'CunnaneTransformer only suppers 1 feature',
+            },
+        }
 
 
 class QuantileMappingReressor(RegressorMixin, BaseEstimator):
@@ -397,7 +418,27 @@ class QuantileMappingReressor(RegressorMixin, BaseEstimator):
         }
 
 
-class CunnaneTransformer:
+class CunnaneTransformer(TransformerMixin, BaseEstimator):
+    """Quantile transform using Cunnane plotting positions with optional extrapolation.
+
+    Parameters
+    ----------
+    alpha : float, optional
+        Plotting positions parameter. Default is 0.4.
+    beta : float, optional
+        Plotting positions parameter. Default is 0.4.       
+    extrapolate : str, optional
+        How to extend the cdfs at the tails. Valid options include {`'min'`, `'max'`, `'both'`, `'1to1'`, `None`}. Default is None.
+    n_endpoints : int
+        Number of endpoints to include when extrapolating the tails of the cdf. Usused if ``extrapolate`` is None. Default is 10.
+
+    Attributes
+    ----------
+    cdf_ : Cdf
+        NamedTuple representing the fit cdf
+    """
+
+    _fit_attributes = ['cdf_']
 
     def __init__(self, *, alpha=0.4, beta=0.4, extrapolate='both', n_endpoints=10):
 
@@ -407,21 +448,49 @@ class CunnaneTransformer:
         self.extrapolate = extrapolate
         self.n_endpoints = n_endpoints
 
-    def fit(self, X):
+    def fit(self, X, y=None):
+        """Compute CDF and plotting positions for X.
+        
+        Parameters
+        ----------
+        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+            The data used to scale along the features axis. If a sparse
+            matrix is provided, it will be converted into a sparse
+            ``csc_matrix``. Additionally, the sparse matrix needs to be
+            nonnegative if `ignore_implicit_zeros` is False.
+        y : None
+            Ignored.
+        
+        Returns
+        -------
+        self : object
+           Fitted transformer.
+        """
 
-        xs = X.squeeze()
+        X = check_array(X, ensure_2d=True)
+        if X.shape[1] > 1:
+            raise ValueError('CunnaneTransformer.fit() only supports a single feature')
+        X = X[:, 0]
+
         self.cdf_ = Cdf(
-            plotting_positions(len(xs)),
-            np.sort(xs)
+            plotting_positions(len(X)),
+            np.sort(X)
         )
         return self
 
     def transform(self, X):
 
+        X = check_array(X, ensure_2d=True)
+
+        if X.shape[1] > 1:
+            raise ValueError('CunnaneTransformer.transform() only supports a single feature')
+        X = X[:, 0]
+
         left = -np.inf if self.extrapolate in ['min', 'both'] else None
         right = np.inf if self.extrapolate in ['max', 'both'] else None
 
-        pps = np.interp(X.squeeze(), self.cdf_.vals, self.cdf_.pp, left=left, right=right)
+        pps = np.interp(X, self.cdf_.vals, self.cdf_.pp, left=left, right=right)
+        
         if np.isinf(pps).any():
             lower_inds = np.nonzero(-np.inf == pps)[0]
             upper_inds = np.nonzero(np.inf == pps)[0]
@@ -429,18 +498,35 @@ class CunnaneTransformer:
             if len(lower_inds):
                 s = slice(None, self.n_endpoints)
                 model.fit(self.cdf_.vals[s].reshape(-1, 1), self.cdf_.pp[s].reshape(-1, 1))
-                pps[lower_inds] = model.predict(X.squeeze()[lower_inds].values.reshape(-1, 1)).squeeze()
+                pps[lower_inds] = model.predict(X[lower_inds].values.reshape(-1, 1)).squeeze()
             if len(upper_inds):
                 s = slice(-self.n_endpoints, None)
                 model.fit(self.cdf_.vals[s].reshape(-1, 1), self.cdf_.pp[s].reshape(-1, 1))
-                pps[upper_inds] = model.predict(X.squeeze()[upper_inds].values.reshape(-1, 1)).squeeze()
+                pps[upper_inds] = model.predict(X[upper_inds].values.reshape(-1, 1)).squeeze()
 
         return pps.reshape(-1, 1)
+
+    def fit_transform(self, X, y=None):
+        """Fit `CunnaneTransform` to `X`, then transform `X`.
+        
+        Parameters
+        ----------
+        X : array-like of shape (n_samples, n_features)
+            The data used to generate the fit CDF.
+        y : Ignored
+            Not used, present for API consistency by convention.
+        
+        Returns
+        -------
+        X_new : ndarray of shape (n_samples, n_features)
+            Transformed data.
+        """
+
+        return self.fit(X).transform(X)
 
     def inverse_transform(self, X):
 
         X = check_array(X, ensure_2d=True)
-
         X = X[:, 0]
 
         left = -np.inf if self.extrapolate in ['min', 'both'] else None
@@ -462,6 +548,34 @@ class CunnaneTransformer:
                 vals[upper_inds] = model.predict(X[upper_inds].reshape(-1, 1)).squeeze()
 
         return vals.reshape(-1, 1)
+
+    def _more_tags(self):
+        return {
+            '_xfail_checks': {
+                'check_estimators_dtypes': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit_score_takes_y': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_data_not_an_array': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_fit_returns_self': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_fit_returns_self(readonly_memmap=True)': 'CunnaneTransformer only suppers 1 feature',
+                'check_dtype_object': 'CunnaneTransformer only suppers 1 feature',
+                'check_pipeline_consistency': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_nan_inf': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_overwrite_params': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_pickle': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit2d_predict1d': 'CunnaneTransformer only suppers 1 feature',
+                'check_methods_subset_invariance': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit2d_1sample': 'CunnaneTransformer only suppers 1 feature',
+                'check_dict_unchanged': 'CunnaneTransformer only suppers 1 feature',
+                'check_dont_overwrite_parameters': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit_idempotent': 'CunnaneTransformer only suppers 1 feature',
+                'check_n_features_in': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_empty_data_messages': 'skip due to odd sklearn string matching in unit test',
+                'check_fit_check_is_fitted': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_general': 'CunnaneTransformer only suppers 1 feature',
+                'check_transformer_preserve_dtypes': 'CunnaneTransformer only suppers 1 feature',
+                'check_methods_sample_order_invariance': 'CunnaneTransformer only suppers 1 feature',
+            },
+        }
 
 
 class EquidistantCdfMatcher(QuantileMappingReressor):

--- a/skdownscale/pointwise_models/quantile.py
+++ b/skdownscale/pointwise_models/quantile.py
@@ -132,33 +132,30 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
         return x_qmapped
 
     def _more_tags(self):
-        return {'_xfail_checks': {'check_methods_subset_invariance': 'because'}}
-
-    def _more_tags(self):
         return {
             '_xfail_checks': {
-                'check_estimators_dtypes': 'CunnaneTransformer only suppers 1 feature',
-                'check_fit_score_takes_y': 'CunnaneTransformer only suppers 1 feature',
-                'check_transformer_data_not_an_array': 'CunnaneTransformer only suppers 1 feature',
-                'check_estimators_fit_returns_self': 'CunnaneTransformer only suppers 1 feature',
-                'check_estimators_fit_returns_self(readonly_memmap=True)': 'CunnaneTransformer only suppers 1 feature',
-                'check_dtype_object': 'CunnaneTransformer only suppers 1 feature',
-                'check_pipeline_consistency': 'CunnaneTransformer only suppers 1 feature',
-                'check_estimators_nan_inf': 'CunnaneTransformer only suppers 1 feature',
-                'check_estimators_overwrite_params': 'CunnaneTransformer only suppers 1 feature',
-                'check_estimators_pickle': 'CunnaneTransformer only suppers 1 feature',
-                'check_fit2d_predict1d': 'CunnaneTransformer only suppers 1 feature',
-                'check_methods_subset_invariance': 'CunnaneTransformer only suppers 1 feature',
-                'check_fit2d_1sample': 'CunnaneTransformer only suppers 1 feature',
-                'check_dict_unchanged': 'CunnaneTransformer only suppers 1 feature',
-                'check_dont_overwrite_parameters': 'CunnaneTransformer only suppers 1 feature',
-                'check_fit_idempotent': 'CunnaneTransformer only suppers 1 feature',
-                'check_n_features_in': 'CunnaneTransformer only suppers 1 feature',
+                'check_estimators_dtypes': 'QuantileMapper only suppers 1 feature',
+                'check_fit_score_takes_y': 'QuantileMapper only suppers 1 feature',
+                'check_transformer_data_not_an_array': 'QuantileMapper only suppers 1 feature',
+                'check_estimators_fit_returns_self': 'QuantileMapper only suppers 1 feature',
+                'check_estimators_fit_returns_self(readonly_memmap=True)': 'QuantileMapper only suppers 1 feature',
+                'check_dtype_object': 'QuantileMapper only suppers 1 feature',
+                'check_pipeline_consistency': 'QuantileMapper only suppers 1 feature',
+                'check_estimators_nan_inf': 'QuantileMapper only suppers 1 feature',
+                'check_estimators_overwrite_params': 'QuantileMapper only suppers 1 feature',
+                'check_estimators_pickle': 'QuantileMapper only suppers 1 feature',
+                'check_fit2d_predict1d': 'QuantileMapper only suppers 1 feature',
+                'check_methods_subset_invariance': 'QuantileMapper only suppers 1 feature',
+                'check_fit2d_1sample': 'QuantileMapper only suppers 1 feature',
+                'check_dict_unchanged': 'QuantileMapper only suppers 1 feature',
+                'check_dont_overwrite_parameters': 'QuantileMapper only suppers 1 feature',
+                'check_fit_idempotent': 'QuantileMapper only suppers 1 feature',
+                'check_n_features_in': 'QuantileMapper only suppers 1 feature',
                 'check_estimators_empty_data_messages': 'skip due to odd sklearn string matching in unit test',
-                'check_fit_check_is_fitted': 'CunnaneTransformer only suppers 1 feature',
-                'check_transformer_general': 'CunnaneTransformer only suppers 1 feature',
-                'check_transformer_preserve_dtypes': 'CunnaneTransformer only suppers 1 feature',
-                'check_methods_sample_order_invariance': 'CunnaneTransformer only suppers 1 feature',
+                'check_fit_check_is_fitted': 'QuantileMapper only suppers 1 feature',
+                'check_transformer_general': 'QuantileMapper only suppers 1 feature',
+                'check_transformer_preserve_dtypes': 'QuantileMapper only suppers 1 feature',
+                'check_methods_sample_order_invariance': 'QuantileMapper only suppers 1 feature',
             },
         }
 
@@ -426,7 +423,7 @@ class CunnaneTransformer(TransformerMixin, BaseEstimator):
     alpha : float, optional
         Plotting positions parameter. Default is 0.4.
     beta : float, optional
-        Plotting positions parameter. Default is 0.4.       
+        Plotting positions parameter. Default is 0.4.
     extrapolate : str, optional
         How to extend the cdfs at the tails. Valid options include {`'min'`, `'max'`, `'both'`, `'1to1'`, `None`}. Default is None.
     n_endpoints : int
@@ -450,17 +447,17 @@ class CunnaneTransformer(TransformerMixin, BaseEstimator):
 
     def fit(self, X, y=None):
         """Compute CDF and plotting positions for X.
-        
+
         Parameters
         ----------
-        X : {array-like, sparse matrix} of shape (n_samples, n_features)
+        X : {array-like, sparse matrix} of shape (n_samples, 1)
             The data used to scale along the features axis. If a sparse
             matrix is provided, it will be converted into a sparse
             ``csc_matrix``. Additionally, the sparse matrix needs to be
             nonnegative if `ignore_implicit_zeros` is False.
         y : None
             Ignored.
-        
+
         Returns
         -------
         self : object
@@ -472,13 +469,22 @@ class CunnaneTransformer(TransformerMixin, BaseEstimator):
             raise ValueError('CunnaneTransformer.fit() only supports a single feature')
         X = X[:, 0]
 
-        self.cdf_ = Cdf(
-            plotting_positions(len(X)),
-            np.sort(X)
-        )
+        self.cdf_ = Cdf(plotting_positions(len(X)), np.sort(X))
         return self
 
     def transform(self, X):
+        """Perform the quantile transform.
+
+        Parameters
+        ----------
+        X : array_like, shape [n_samples, 1]
+            Samples.
+
+        Returns
+        -------
+        y : ndarray of shape (n_samples, )
+            Transformed data
+        """
 
         X = check_array(X, ensure_2d=True)
 
@@ -490,7 +496,7 @@ class CunnaneTransformer(TransformerMixin, BaseEstimator):
         right = np.inf if self.extrapolate in ['max', 'both'] else None
 
         pps = np.interp(X, self.cdf_.vals, self.cdf_.pp, left=left, right=right)
-        
+
         if np.isinf(pps).any():
             lower_inds = np.nonzero(-np.inf == pps)[0]
             upper_inds = np.nonzero(np.inf == pps)[0]
@@ -508,14 +514,14 @@ class CunnaneTransformer(TransformerMixin, BaseEstimator):
 
     def fit_transform(self, X, y=None):
         """Fit `CunnaneTransform` to `X`, then transform `X`.
-        
+
         Parameters
         ----------
         X : array-like of shape (n_samples, n_features)
             The data used to generate the fit CDF.
         y : Ignored
             Not used, present for API consistency by convention.
-        
+
         Returns
         -------
         X_new : ndarray of shape (n_samples, n_features)

--- a/skdownscale/pointwise_models/quantile.py
+++ b/skdownscale/pointwise_models/quantile.py
@@ -122,7 +122,7 @@ class QuantileMapper(TransformerMixin, BaseEstimator):
         # do the final mapping
         qt_kws = default_none_kwargs(self.qt_kwargs, copy=True)
 
-        x_quantiles = CunnaneTransformer(**qt_kws).fit(x_to_cdf).transform(x_to_cdf)
+        x_quantiles = CunnaneTransformer(**qt_kws).fit_transform(x_to_cdf)
         x_qmapped = self.x_cdf_fit_.inverse_transform(x_quantiles)
 
         # add the trend back

--- a/skdownscale/test/test_pointwise_models.py
+++ b/skdownscale/test/test_pointwise_models.py
@@ -8,6 +8,7 @@ from skdownscale.pointwise_models import (
     AnalogRegression,
     BcsdPrecipitation,
     BcsdTemperature,
+    CunnaneTransformer,
     EquidistantCdfMatcher,
     LinearTrendTransformer,
     PaddedDOYGrouper,
@@ -44,6 +45,7 @@ def sample_X_y(n=365):
         EquidistantCdfMatcher(kind='ratio', n_endpoints=2),
         # transformers
         LinearTrendTransformer(),
+        CunnaneTransformer(),
         QuantileMapper(),
     ]
 )


### PR DESCRIPTION
This PR adds a new quantile transformer. It functions similarly to scikit-learn's `QuantileMapper` but has a few extra features/parameters:

- uses Cunnane plotting positions
- optionally supports extrapolation when plotting positions are outside the bounds of the fit CDF
- is much faster for datasets with > 2500 samples 