### PR TITLE
change exceedance prob from prob of dry to prob of rain

### DIFF
--- a/skdownscale/pointwise_models/gard.py
+++ b/skdownscale/pointwise_models/gard.py
@@ -426,7 +426,8 @@ class PureRegression(RegressorMixin, NamedColumnBaseEstimator):
         check_is_fitted(self)
 
         if self.thresh is not None:
-            exceedance_prob = self.logistic_model_.predict_proba(X)[:, 0]
+            # 0 accesses the probability of no rain, 1 accesses probability of rainy day
+            exceedance_prob = self.logistic_model_.predict_proba(X)[:, 1]
         else:
             exceedance_prob = np.ones(len(np.asarray(X)), dtype=np.float64)
 


### PR DESCRIPTION
This change grabs the code to grab the second column which is the probability that it will exceed the threshold (and in the application of GARD that corresponds to the probability of it raining). This simplifies the use of the results elsewhere and limits doing any `1-exceedance` in other locations.