### PR TITLE
Switch np.object to object

### DIFF
--- a/skdownscale/pointwise_models/core.py
+++ b/skdownscale/pointwise_models/core.py
@@ -62,10 +62,10 @@ def _fit_wrapper(X, *args, along_dim='time', feature_dim=DEFAULT_FEATURE_DIM, **
 
     # create the empty output array
     models = xr.DataArray(
-        np.full(mask.shape, None, dtype=np.object), coords=mask.coords, dims=mask.dims
+        np.full(mask.shape, None, dtype=object), coords=mask.coords, dims=mask.dims
     )
 
-    scalar_obj = np.empty((1), dtype=np.object)
+    scalar_obj = np.empty((1), dtype=object)
     for index, val in xenumerate(mask):
         mod = copy.deepcopy(model)
         if not val:


### PR DESCRIPTION
Following https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated to silence a bunch of deprecation warnings.

Currently this will spill a bunch of 

```python-traceback
AttributeError: module 'numpy' has no attribute 'object'
```

since it is being applied pointwise.